### PR TITLE
Fixed bug in authorization code that prevents any request from going through

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -4,7 +4,7 @@ import basicAuth from 'basic-auth-header';
 export default (url, options) => fetch(url, {
   method: options.method,
   headers: Object.assign({}, options.headers, options.auth && {
-    Authorization: basicAuth(options.auth.user, options.user.pass),
+    Authorization: basicAuth(options.auth.user, options.auth.pass),
   }),
   body: typeof options.body === 'string' ? options.body : JSON.stringify(options.body),
 }).then(res => res.json());


### PR DESCRIPTION
`pass` is available on auth instead of on user